### PR TITLE
Remove the dashboard for Developers Italia

### DIFF
--- a/it/progetti/developers-italia.md
+++ b/it/progetti/developers-italia.md
@@ -9,7 +9,7 @@ ref: developers-italia
 logo: developers-italia.png
 child_of_ref: progetti
 project_url: https://developers.italia.it/
-dashboard_url: https://dashboard.pdnd.italia.it/public/dashboard/08665701-33b7-49ac-acd8-dee59a150737
+dashboard_url: 
 people:
 no_site_toc: true
 order: 5


### PR DESCRIPTION
The dashboard for Developers Italia is not ready for publishing yet.
Let's wait until we merge the original Pull Request: https://github.com/teamdigitale/teamdigitale.governo.it/pull/798