### PR TITLE
feat: enable html-proofer for external links

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ references:
           --allow-hash-href \
           --only-4xx \
           --alt-ignore '/.*/' \
-          --disable_external true
+          --disable_external false
 
   save_to_workspace: &save_to_workspace
     persist_to_workspace:


### PR DESCRIPTION
This will enable html-proofer to check also external links which sometimes can results in broken links. It adds a little more effort to compute them but should be irrilevant.